### PR TITLE
Proposal for schema stitching at runtime - prevent links from getting added twice

### DIFF
--- a/LinkDirective.js
+++ b/LinkDirective.js
@@ -83,6 +83,11 @@ export default class LinkDirective extends SchemaDirectiveVisitor {
       }
     }
 
+    // Check if a link already exists. 
+    // This should be beefed up to check all the ways it could be a different link.
+    if (thisCollection.__links && thisCollection.__links[field.name]) {
+      return
+    };
     thisCollection.addLinks({
       [field.name]: {
         collection: referencedCollection,


### PR DESCRIPTION
This PR is part of a bigger effort discussed in the [cult-of-coders/apollo repo](https://github.com/cult-of-coders/apollo/pull/20). When I attempted to initialize the apollo package a second time at runtime Grapher throws because it will addLinks to collections that already have links. I hoping to learn the right way to do it via feedback to these PRs but I wanted to show some effort up front. Like a proof of concept.

My initial thoughts are that this is a very brittle check and links could be different in more way than the ```field.name```. So looking for advice on a better way to "refresh" grapher with a new graphql schema.